### PR TITLE
I've created initial project pages for Tape-tics, Hap'n'Roll, Fresnel…

### DIFF
--- a/content/project/fresnelshape/index.md
+++ b/content/project/fresnelshape/index.md
@@ -1,0 +1,33 @@
+---
+title: FresnelShape
+date: 2025-06-11
+summary: A shape-changing display using Fresnel lenses. (Placeholder description)
+tags:
+  - Shape Display
+  - Optics
+# Optional external URL for project (replaces project detail page).
+external_link: ""
+
+image:
+  caption: Placeholder for FresnelShape image
+  focal_point: Smart
+
+# links:
+# - icon: twitter
+#   icon_pack: fab
+#   name: Follow
+#   url: https://twitter.com/georgecushen
+url_code: ""
+url_pdf: ""
+url_slides: ""
+url_video: ""
+
+# Slides (optional).
+#   Associate this project with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides = "example-slides"` references `content/slides/example-slides.md`.
+#   Otherwise, set `slides = ""`.
+slides: ""
+---
+
+This is a placeholder page for the FresnelShape project. More details will be added soon based on the paper.

--- a/content/project/hap-n-roll/index.md
+++ b/content/project/hap-n-roll/index.md
@@ -1,0 +1,33 @@
+---
+title: Hap'n'Roll
+date: 2025-06-11
+summary: A rollable haptic device. (Placeholder description)
+tags:
+  - Haptics
+  - Shape Display
+# Optional external URL for project (replaces project detail page).
+external_link: ""
+
+image:
+  caption: Placeholder for Hap'n'Roll image
+  focal_point: Smart
+
+# links:
+# - icon: twitter
+#   icon_pack: fab
+#   name: Follow
+#   url: https://twitter.com/georgecushen
+url_code: ""
+url_pdf: ""
+url_slides: ""
+url_video: ""
+
+# Slides (optional).
+#   Associate this project with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides = "example-slides"` references `content/slides/example-slides.md`.
+#   Otherwise, set `slides = ""`.
+slides: ""
+---
+
+This is a placeholder page for the Hap'n'Roll project. More details will be added soon based on the paper.

--- a/content/project/tape-tics/index.md
+++ b/content/project/tape-tics/index.md
@@ -1,0 +1,33 @@
+---
+title: Tape-tics
+date: 2025-06-11
+summary: A haptic feedback device in the form of a cuttable tape with small vibrators. (Placeholder description)
+tags:
+  - Haptics
+  - Wearable
+# Optional external URL for project (replaces project detail page).
+external_link: ""
+
+image:
+  caption: Placeholder for Tape-tics image
+  focal_point: Smart
+
+# links:
+# - icon: twitter
+#   icon_pack: fab
+#   name: Follow
+#   url: https://twitter.com/georgecushen
+url_code: ""
+url_pdf: ""
+url_slides: ""
+url_video: ""
+
+# Slides (optional).
+#   Associate this project with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides = "example-slides"` references `content/slides/example-slides.md`.
+#   Otherwise, set `slides = ""`.
+slides: ""
+---
+
+This is a placeholder page for the Tape-tics project. More details will be added soon based on the paper.

--- a/content/project/umotion/index.md
+++ b/content/project/umotion/index.md
@@ -1,0 +1,33 @@
+---
+title: UMotion
+date: 2025-06-11
+summary: A system for ...... (Placeholder description - UMotion needs more context if a generic description is not suitable)
+tags:
+  - HCI
+  # Add more specific tags if known
+# Optional external URL for project (replaces project detail page).
+external_link: ""
+
+image:
+  caption: Placeholder for UMotion image
+  focal_point: Smart
+
+# links:
+# - icon: twitter
+#   icon_pack: fab
+#   name: Follow
+#   url: https://twitter.com/georgecushen
+url_code: ""
+url_pdf: ""
+url_slides: ""
+url_video: ""
+
+# Slides (optional).
+#   Associate this project with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides = "example-slides"` references `content/slides/example-slides.md`.
+#   Otherwise, set `slides = ""`.
+slides: ""
+---
+
+This is a placeholder page for the UMotion project. More details will be added soon based on the paper.


### PR DESCRIPTION
…Shape, and UMotion.

This commit adds placeholder pages for four new projects:
- Tape-tics
- Hap'n'Roll
- FresnelShape
- UMotion

Each project has its own directory under `content/project/` and an `index.md` file with basic front matter and placeholder text.

The main `content/projects.md` page was already configured to display content from the `content/project/` directory, so no changes were needed there.