### PR TITLE
This commit removes the 'Recent & Upcoming Talks' section from the ho…

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -60,16 +60,6 @@ sections:
     design:
       view: citation
   - block: collection
-    id: talks
-    content:
-      title: Recent & Upcoming Talks
-      filters:
-        folders:
-          - event
-    design:
-      view: article-grid
-      columns: 1
-  - block: collection
     id: news
     content:
       title: Recent News


### PR DESCRIPTION
…mepage (`content/_index.md`) as per your request.